### PR TITLE
[audit fix] DOS.extractNFT index bug

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -165,12 +165,14 @@ overrides:
     env:
       mocha: true
     rules:
+      no-underscore-dangle: off
       "@typescript-eslint/no-magic-numbers": off
       "@typescript-eslint/no-non-null-assertion": off
       "@typescript-eslint/naming-convention": off
       "@typescript-eslint/no-unsafe-assignment": off
       "@typescript-eslint/no-unsafe-call": off
       "@typescript-eslint/no-unsafe-argument": off
+      "@typescript-eslint/no-unused-vars": [error, {varsIgnorePattern: "^_"}]
       # consider disabling rules below as needed
       # "@typescript-eslint/no-unsafe-declaration-merging": off
       # "@typescript-eslint/no-unsafe-member-access": off

--- a/contracts/dos/DOS.sol
+++ b/contracts/dos/DOS.sol
@@ -179,6 +179,7 @@ library DSafeLib {
         } else {
             NFTId lastNFTId = dSafe.nfts[dSafe.nfts.length - 1];
             map[lastNFTId].dSafeIdx = idx;
+            dSafe.nfts[idx] = lastNFTId;
             dSafe.nfts.pop();
         }
     }

--- a/test/dos/dos.test.ts
+++ b/test/dos/dos.test.ts
@@ -810,6 +810,23 @@ describe("DOS", () => {
         expect(await iDos.getDAccountERC721(dSafe.address)).to.eql([]);
       },
     );
+
+    it(
+      "[regression] when user owns two deposited NFT " +
+        "should be able to withdraw the first deposited and then the second deposited",
+      async () => {
+        const {user, iDos, nft, nftOracle} = await loadFixture(deployDOSFixture);
+        const dSafe = await createDSafe(iDos, user);
+        const _tokenId1 = await depositERC721(iDos, dSafe, nft, nftOracle, NFT_PRICE);
+        const tokenId2 = await depositERC721(iDos, dSafe, nft, nftOracle, NFT_PRICE);
+        const _tokenId3 = await depositERC721(iDos, dSafe, nft, nftOracle, NFT_PRICE);
+
+        const withdrawERC721Tx = await dSafe.executeBatch([
+          makeCall(iDos).withdrawERC721(nft.address, tokenId2),
+        ]);
+        await expect(withdrawERC721Tx.wait()).not.to.be.reverted;
+      },
+    );
   });
 
   describe("#transferERC721", () => {


### PR DESCRIPTION
the fix and the the regression test on it. From the audit report:

### 3. Wrong value removed in extractNFT

**Severity**: High

**Difficulty**: Low

**Type**: Undefined Behavior Finding ID: TOB-DOS-3

**Target**: DOS.sol

##### Description
An implementation mistake in extractNFT can lead to users being unable to withdraw
their NFTs.
In extractNFT, swap-and-pop is used to remove dSafe.nfts[idx] from the list (which
contains a dSafe’s NFTs):
```solidity
// Figure 3.1: Attempted swap-and-pop in DOS.sol

NFTId lastNFTId = dSafe.nfts[dSafe.nfts.length - 1];
map[lastNFTId].dSafeIdx = idx;
dSafe.nfts.pop();
```
However, `dSafe.nfts[idx]` is never replaced with the final element in the list, so
`dSafe.nfts[idx]` is kept, with `dSafe.nfts[dSafe.nfts.length-1]` being removed
instead. This results in an incorrect list of NFTs owned by the dSafe. Later, this results in
isSolvent reverting, making the withdrawal of this NFT impossible.

##### Exploit scenario
Alice, who owns a dSafe with 3 NFTs, tries to withdraw the 2nd NFT, but the transaction
reverts, making it not possible to withdraw the NFT.

##### Recommendations
Short term, change the code so that dSafe.nfts[idx] is overwritten with lastNFTid.
Long term, add more extensive tests that can catch similar accounting errors.